### PR TITLE
feat: curlでpostした文字列をそのまま返す機能を作成

### DIFF
--- a/nlp/nlp_module.py
+++ b/nlp/nlp_module.py
@@ -1,0 +1,2 @@
+def correct(text):
+    return text

--- a/nlp/nlp_server.py
+++ b/nlp/nlp_server.py
@@ -1,0 +1,23 @@
+# import nlp_module
+from flask import Flask, jsonify, request
+
+
+app = Flask(__name__)
+app.config['JSON_AS_ASCII'] = False
+
+
+@app.route('/')
+def index():
+    return "Hello, nlp"
+
+
+@app.route('/correct', methods=['POST'], endpoint="correct-text")
+def correct_text():
+    data = request.get_json()
+    text = data['text']
+    corrected_text = text
+    return jsonify({'corrected_text': corrected_text})
+
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=5000)


### PR DESCRIPTION
変更の概要：curlでpostした文字列をそのまま返す機能を作成しました

なぜこの変更をするのか：

やったこと：nlp_server.pyでcorrect_text関数を定義し、curlでjson形式{'text': '内容'}でpostするとそのまま返す機能を作成しました。

やらないこと：文章校正機能については未実装です。実装ができ次第、別のプルリクエストで対応します

影響範囲：

どうやるのか：

```linux
curl -X POST -H "Content-Type: application/json" -d '{"text": "日本語の文章"}'http://127.0.0.1:5000/correct
```
などのコマンドを打つと
```linux
{"corrected_text": "日本語の文章"}
```
が返ってくる

課題：特に日本語の文字化けを防ぐ「app.config['JSON_AS_ASCII'] = False」が影響してバグが起こらないかどうかレビューしてほしい

備考：